### PR TITLE
fix ore generation

### DIFF
--- a/kci-nms26plus/src/main/java/nl/knokko/customitems/nms26plus/KciNms26Plus.java
+++ b/kci-nms26plus/src/main/java/nl/knokko/customitems/nms26plus/KciNms26Plus.java
@@ -16,7 +16,7 @@ public class KciNms26Plus extends KciNms21Plus {
 
 	@Override
 	public String getBiomeKey(Biome biome) {
-		NamespacedKey key = biome.getKeyOrNull();
+		NamespacedKey key = biome.getKey();
 		if (key == null) return null;
 		return key.getKey();
 	}


### PR DESCRIPTION
@Override
   2 public String getBiomeKey(Biome biome) {
   3     NamespacedKey key = biome.getKeyOrNull(); // <- Cette méthode causait le crash
   4     if (key == null) return null;
   5     return key.getKey();
   6 }

  Après :

   1 @Override
   2 public String getBiomeKey(Biome biome) {
   3     NamespacedKey key = biome.getKey(); // <- Méthode correcte et officielle
   4     if (key == null) return null;
   5     return key.getKey();
   6 }